### PR TITLE
Relationship endpoints/merchants

### DIFF
--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::InvoicesController < ApplicationController
+  def index
+    render json: InvoiceSerializer.new(Invoice.where(merchant_id: params[:merchant_id]))
+  end
+end

--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::ItemsController < ApplicationController
+  def index
+
+  end 
+end

--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::ItemsController < ApplicationController
   def index
-
-  end 
+    render json: ItemSerializer.new(Item.where(merchant_id: params[:merchant_id]))
+  end
 end

--- a/app/serializers/invoice_serializer.rb
+++ b/app/serializers/invoice_serializer.rb
@@ -1,0 +1,4 @@
+class InvoiceSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :id, :customer_id, :merchant_id, :status
+end

--- a/app/serializers/item_serializer.rb
+++ b/app/serializers/item_serializer.rb
@@ -1,0 +1,4 @@
+class ItemSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :id, :name, :description, :unit_price, :merchant_id
+end

--- a/app/serializers/merchant_serializer.rb
+++ b/app/serializers/merchant_serializer.rb
@@ -2,4 +2,5 @@ class MerchantSerializer
   include FastJsonapi::ObjectSerializer
   attributes :id, :name
   has_many :items #should this be here?
+  has_many :invoices #and this?
 end

--- a/app/serializers/merchant_serializer.rb
+++ b/app/serializers/merchant_serializer.rb
@@ -1,4 +1,5 @@
 class MerchantSerializer
   include FastJsonapi::ObjectSerializer
   attributes :id, :name
+  has_many :items #should this be here?
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,8 +5,8 @@ Rails.application.routes.draw do
       get 'merchants/find', to: 'merchants#find'
       resources :merchants, only: [:index, :show] do
         resources :items, only: [:index]
+        resources :invoices, only: [:index]
       end
-
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,9 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       get 'merchants/find', to: 'merchants#find'
-      resources :merchants, only: [:index, :show]
+      resources :merchants, only: [:index, :show] do
+        resources :items, only: [:index]
+      end
 
     end
   end

--- a/spec/factories/invoices.rb
+++ b/spec/factories/invoices.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :invoice do
     status { "MyString" }
+    customer
   end
 end

--- a/spec/factories/invoices.rb
+++ b/spec/factories/invoices.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :invoice do
-    status { "MyString" }
+    status { "shipped" }
     customer
   end
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :item do
-    name { "MyString" }
-    description { "MyText" }
-    unit_price { 1 }
+    sequence(:name) { |n| "Item #{n}"}
+    sequence(:description) { |n| "Description #{n}" }
+    sequence(:unit_price) { |n| n }
   end
 end

--- a/spec/requests/api/v1/merchants_request_spec.rb
+++ b/spec/requests/api/v1/merchants_request_spec.rb
@@ -61,4 +61,13 @@ describe "Merchants API" do
 
     end
   end
+
+  it "sends a list of items associated with a merchant" do
+    merchant = create(:merchant)
+    create_list(:item, 3, merchant: merchant)
+
+    get "/api/v1/merchants/#{merchant.id}/items"
+
+    expect(response).to be_successful
+  end
 end

--- a/spec/requests/api/v1/merchants_request_spec.rb
+++ b/spec/requests/api/v1/merchants_request_spec.rb
@@ -78,4 +78,21 @@ describe "Merchants API" do
       expect(item["attributes"]["merchant_id"]).to eq(merchant.id)
     end
   end
+
+  it "sends a list of invoices associated with a merchant" do
+    merchant = create(:merchant)
+    create_list(:invoice, 3, merchant: merchant)
+
+    get "/api/v1/merchants/#{merchant.id}/invoices"
+
+    expect(response).to be_successful
+
+    invoices = JSON.parse(response.body)['data']
+
+    expect(invoices.count).to eq(3)
+    
+    invoices.each do |invoice|
+      expect(invoice["attributes"]["merchant_id"]).to eq(merchant.id)
+    end
+  end
 end

--- a/spec/requests/api/v1/merchants_request_spec.rb
+++ b/spec/requests/api/v1/merchants_request_spec.rb
@@ -69,5 +69,13 @@ describe "Merchants API" do
     get "/api/v1/merchants/#{merchant.id}/items"
 
     expect(response).to be_successful
+
+    items = JSON.parse(response.body)['data']
+
+    expect(items.count).to eq(3)
+
+    items.each do |item|
+      expect(item["attributes"]["merchant_id"]).to eq(merchant.id)
+    end
   end
 end

--- a/spec/requests/api/v1/merchants_request_spec.rb
+++ b/spec/requests/api/v1/merchants_request_spec.rb
@@ -11,7 +11,7 @@ describe "Merchants API" do
     merchants = JSON.parse(response.body)['data']
 
     expect(merchants.count).to eq(3)
-    expect(merchants.first.keys).to eq(["id", "type", "attributes"])
+    expect(merchants.first.keys).to eq(["id", "type", "attributes", "relationships"])
   end
 
   it "can get one merchant by its id" do

--- a/spec/requests/api/v1/merchants_request_spec.rb
+++ b/spec/requests/api/v1/merchants_request_spec.rb
@@ -75,6 +75,7 @@ describe "Merchants API" do
     expect(items.count).to eq(3)
 
     items.each do |item|
+      expect(item["attributes"].keys).to eq(["id", "name", "description", "unit_price", "merchant_id"])
       expect(item["attributes"]["merchant_id"]).to eq(merchant.id)
     end
   end
@@ -90,8 +91,9 @@ describe "Merchants API" do
     invoices = JSON.parse(response.body)['data']
 
     expect(invoices.count).to eq(3)
-    
+
     invoices.each do |invoice|
+      expect(invoice["attributes"].keys).to eq(["id", "customer_id", "merchant_id", "status"])
       expect(invoice["attributes"]["merchant_id"]).to eq(merchant.id)
     end
   end


### PR DESCRIPTION
**Functionality** 
- Adds relationship endpoints for `/api/v1/merchants/:id/items` & `/api/v1/merchants/:id/invoices`

**Testing** 
- Spec harness merchant relationships tests all passing
- Rspec at 97.79% due to skipped tests
- Consider moving relationship tests into their own file
- More testing for relationships?

**Issues** 
#33 