### PR TITLE
Record endpoints/merchants/random

### DIFF
--- a/app/controllers/api/v1/merchants/random_controller.rb
+++ b/app/controllers/api/v1/merchants/random_controller.rb
@@ -1,7 +1,5 @@
 class Api::V1::Merchants::RandomController < ApplicationController
   def show
-    merchant = Merchant.order(Arel.sql('random()')).limit(1)
-
-    render json: MerchantSerializer.new(merchant)
+    render json: MerchantSerializer.new(Merchant.random)
   end
 end

--- a/app/controllers/api/v1/merchants/random_controller.rb
+++ b/app/controllers/api/v1/merchants/random_controller.rb
@@ -1,0 +1,7 @@
+class Api::V1::Merchants::RandomController < ApplicationController
+  def show
+    merchant = Merchant.order(Arel.sql('random()')).limit(1)
+
+    render json: MerchantSerializer.new(merchant)
+  end
+end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -13,4 +13,8 @@ class Merchant < ApplicationRecord
   def self.highest_revenue(limit)
     joins(invoices: [:invoice_items, :transactions]).select("merchants.*, sum(invoice_items.unit_price * invoice_items.quantity) AS revenue").group(:id).merge(Transaction.successful).order("revenue DESC").limit(limit)
   end
+
+  def self.random
+    order(Arel.sql('random()')).limit(1).first
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       namespace :merchants do
+        get '/random', to: 'random#show'
         get '/most_revenue', to: 'revenue#index'
         get '/find', to: 'search#show'
         get '/find_all', to: 'search#index'

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -43,5 +43,21 @@ RSpec.describe Merchant, type: :model do
         expect(merchants).to eq([merchant_4, merchant_2, merchant_1, merchant_5, merchant_3])
       end
     end
+
+    describe "#random" do
+      it "returns one random merchant" do
+        create_list(:merchant, 10)
+        merchants = Merchant.all
+        merchant = merchants.random
+
+        expect(merchant.class).to eq(Merchant)
+
+        expected_merchant = Merchant.last
+
+        allow(merchants).to receive(:random).and_return(expected_merchant)
+
+        expect(merchants.random).to eq(expected_merchant)
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/merchants/merchants_request_spec.rb
+++ b/spec/requests/api/v1/merchants/merchants_request_spec.rb
@@ -25,6 +25,7 @@ describe "Merchants API" do
       expect(response).to be_successful
       expect(merchant["id"]).to eq(id)
     end
+  end
 
   describe "single finders" do
     describe "can get one merchant by any attribute:" do
@@ -173,6 +174,26 @@ describe "Merchants API" do
     end
   end
 
+  describe "random" do
+    it "returns a random merchant" do
+      merchants = create_list(:merchant, 10)
+
+      get "/api/v1/merchants/random"
+
+      expect(response).to be_successful
+
+      number_of_merchants = JSON.parse(response.body).count
+      expect(number_of_merchants).to eq(1)
+
+      random_merchant = JSON.parse(response.body)['data'].first
+
+      expect(random_merchant['type']).to eq('merchant')
+      expect(random_merchant['attributes'].keys).to eq(['id', 'name'])
+
+      result = merchants.one? { |merchant| merchant.id == random_merchant['attributes']['id'] }
+      expect(result).to be(true)
+
+    end
   end
 
   describe "relationships" do

--- a/spec/requests/api/v1/merchants/merchants_request_spec.rb
+++ b/spec/requests/api/v1/merchants/merchants_request_spec.rb
@@ -192,6 +192,17 @@ describe "Merchants API" do
 
       result = merchants.one? { |merchant| merchant.id == random_merchant['attributes']['id'] }
       expect(result).to be(true)
+
+      #stubbed test
+      expected_merchant = Merchant.last
+      allow(Merchant).to receive(:random).and_return(expected_merchant)
+
+      get "/api/v1/merchants/random"
+
+      random_merchant_2 = JSON.parse(response.body)['data']
+      
+      expect(random_merchant_2['type']).to eq('merchant')
+      expect(random_merchant_2['attributes']['id']).to eq(expected_merchant.id)
     end
   end
 

--- a/spec/requests/api/v1/merchants/merchants_request_spec.rb
+++ b/spec/requests/api/v1/merchants/merchants_request_spec.rb
@@ -185,14 +185,13 @@ describe "Merchants API" do
       number_of_merchants = JSON.parse(response.body).count
       expect(number_of_merchants).to eq(1)
 
-      random_merchant = JSON.parse(response.body)['data'].first
+      random_merchant = JSON.parse(response.body)['data']
 
       expect(random_merchant['type']).to eq('merchant')
       expect(random_merchant['attributes'].keys).to eq(['id', 'name'])
 
       result = merchants.one? { |merchant| merchant.id == random_merchant['attributes']['id'] }
       expect(result).to be(true)
-
     end
   end
 


### PR DESCRIPTION
**Functionality**
- Adds endpoint for `/merchants/random` to return a random merchant
- Current working as a merchant model method, to be moved later for use on other resources

**Testing**
- 99.25% covered 
- There were no tests for random endpoint in spec harness, 90 failing tests are still left 

**Related Issues**
- #32 