### PR TITLE
Record endpoints/invoice items/index show finders

### DIFF
--- a/app/controllers/api/v1/invoice_items/random_controller.rb
+++ b/app/controllers/api/v1/invoice_items/random_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::InvoiceItems::RandomController < ApplicationController
+  def show
+    render json: InvoiceItemSerializer.new(InvoiceItem.random)
+  end
+end

--- a/app/controllers/api/v1/invoice_items/search_controller.rb
+++ b/app/controllers/api/v1/invoice_items/search_controller.rb
@@ -1,0 +1,30 @@
+class Api::V1::InvoiceItems::SearchController < ApplicationController
+  def index
+    # if search_params[:name] || params[:description]
+    #   render json: InvoiceItemSerializer.new(InvoiceItem.find_all_case_insensitive(search_params))
+    # else
+      render json: InvoiceItemSerializer.new(InvoiceItem.order(:id).where(search_params))
+    # end
+  end
+
+  def show
+    # require "pry"; binding.pry
+    # if params[:name] || params[:description]
+      # render json: InvoiceItemSerializer.new(InvoiceItem.find_one_case_insensitive(search_params))
+    # else
+    render json: InvoiceItemSerializer.new(InvoiceItem.order(:id).find_by(search_params))
+    # end
+  end
+
+  private
+    def search_params
+      convert_unit_price if params[:unit_price]
+      params.permit(:id, :quantity, :item_id, :invoice_id, :unit_price, :created_at, :updated_at)
+    end
+
+    def convert_unit_price
+      if params[:unit_price].include?(".")
+        params[:unit_price] = "#{(params[:unit_price].to_f * 100).round}"
+      end
+    end
+end

--- a/app/controllers/api/v1/invoice_items/search_controller.rb
+++ b/app/controllers/api/v1/invoice_items/search_controller.rb
@@ -1,19 +1,10 @@
 class Api::V1::InvoiceItems::SearchController < ApplicationController
   def index
-    # if search_params[:name] || params[:description]
-    #   render json: InvoiceItemSerializer.new(InvoiceItem.find_all_case_insensitive(search_params))
-    # else
-      render json: InvoiceItemSerializer.new(InvoiceItem.order(:id).where(search_params))
-    # end
+    render json: InvoiceItemSerializer.new(InvoiceItem.order(:id).where(search_params))
   end
 
   def show
-    # require "pry"; binding.pry
-    # if params[:name] || params[:description]
-      # render json: InvoiceItemSerializer.new(InvoiceItem.find_one_case_insensitive(search_params))
-    # else
     render json: InvoiceItemSerializer.new(InvoiceItem.order(:id).find_by(search_params))
-    # end
   end
 
   private

--- a/app/controllers/api/v1/invoice_items_controller.rb
+++ b/app/controllers/api/v1/invoice_items_controller.rb
@@ -1,0 +1,9 @@
+class Api::V1::InvoiceItemsController < ApplicationController
+  def index
+    render json: InvoiceItemSerializer.new(InvoiceItem.all)
+  end
+
+  def show
+    render json: InvoiceItemSerializer.new(InvoiceItem.find(params[:id]))
+  end
+end

--- a/app/serializers/invoice_item_serializer.rb
+++ b/app/serializers/invoice_item_serializer.rb
@@ -1,4 +1,8 @@
 class InvoiceItemSerializer
   include FastJsonapi::ObjectSerializer
-  attributes :id, :quantity, :unit_price, :item_id, :invoice_id
+  attributes :id, :quantity, :item_id, :invoice_id
+
+  attribute :unit_price do |invoice_item|
+    "#{invoice_item.unit_price/100.to_f}"
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,6 +57,12 @@ Rails.application.routes.draw do
         end
       end
 
+      namespace :invoice_items do
+        get '/random', to: 'random#show'
+        get '/find', to: 'search#show'
+        get '/find_all', to: 'search#index'
+      end
+
       resources :invoice_items, only: [:index, :show]
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,7 +38,7 @@ Rails.application.routes.draw do
         get '/find', to: 'search#show'
         get '/find_all', to: 'search#index'
       end
-      
+
       resources :customers, only: [:index, :show] do
         scope module: 'customers' do
           resources :invoices, only: [:index]
@@ -56,6 +56,8 @@ Rails.application.routes.draw do
           get '/merchant', to: 'merchants#show'
         end
       end
+
+      resources :invoice_items, only: [:index, :show]
     end
   end
 end

--- a/spec/requests/api/v1/invoice_items/invoice_items_endpoint_spec.rb
+++ b/spec/requests/api/v1/invoice_items/invoice_items_endpoint_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+describe "Invoice Items API" do
+  describe "record endpoints" do
+    it "sends a list of invoice_items" do
+      create_list(:invoice_item, 3)
+
+      get '/api/v1/invoice_items'
+
+      expect(response).to be_successful
+
+      invoice_items = JSON.parse(response.body)['data']
+
+      expect(invoice_items.count).to eq(3)
+      expect(invoice_items.first.keys).to eq(["id", "type", "attributes"])
+      expect(invoice_items.first['attributes'].keys).to match_array(['id', 'quantity', 'unit_price', 'item_id', 'invoice_id'])
+    end
+
+    it "can get one item by its id" do
+      invoice_item = create(:invoice_item)
+      unit_price = (invoice_item.unit_price / 100.to_f).to_s
+
+      get "/api/v1/invoice_items/#{invoice_item.id}"
+
+      expect(response).to be_successful
+
+      found_invoice_item = JSON.parse(response.body)['data']
+
+      expect(found_invoice_item['attributes']['id']).to eq(invoice_item.id)
+      expect(found_invoice_item['attributes']['quantity']).to eq(invoice_item.quantity)
+      expect(found_invoice_item['attributes']['item_id']).to eq(invoice_item.item_id)
+      expect(found_invoice_item['attributes']['unit_price']).to eq(unit_price)
+      expect(found_invoice_item['attributes']['invoice_id']).to eq(invoice_item.invoice_id)
+    end
+  end
+end

--- a/spec/requests/api/v1/invoice_items/invoice_items_finders_spec.rb
+++ b/spec/requests/api/v1/invoice_items/invoice_items_finders_spec.rb
@@ -1,0 +1,206 @@
+require 'rails_helper'
+
+RSpec.describe "Invoice Items API" do
+  describe "finders" do
+    describe "single finders" do
+      describe "can get one invoice_item by any attribute:" do
+        before :each do
+          @invoice_item = create(:invoice_item, unit_price: 27409, quantity: 100, created_at: "2020-01-30", updated_at: "2020-01-31")
+          create_list(:invoice_item, 2)
+        end
+
+        it "id" do
+          get "/api/v1/invoice_items/find?id=#{@invoice_item.id}"
+
+          invoice_item = JSON.parse(response.body)['data']
+          expect(response).to be_successful
+
+          expect(invoice_item['attributes']['id']).to eq(@invoice_item.id)
+        end
+
+        it "quantity" do
+          get "/api/v1/invoice_items/find?quantity=#{@invoice_item.quantity}"
+
+          invoice_item = JSON.parse(response.body)['data']
+
+          expect(response).to be_successful
+          expect(invoice_item['attributes']['id']).to eq(@invoice_item.id)
+        end
+
+        it "unit_price" do
+          unit_price = "274.09"
+          get "/api/v1/invoice_items/find?unit_price=#{unit_price}"
+
+          item_invoice = JSON.parse(response.body)['data']
+          expect(response).to be_successful
+
+          expect(item_invoice['attributes']['id']).to eq(@invoice_item.id)
+        end
+
+        it "created_at" do
+          date = @invoice_item.created_at.to_s
+
+          get "/api/v1/invoice_items/find?created_at=#{date}"
+
+          invoice_item = JSON.parse(response.body)['data']
+
+          expect(response).to be_successful
+          expect(invoice_item['attributes']['id']).to eq(@invoice_item.id)
+        end
+
+        it "updated_at" do
+          date = @invoice_item.updated_at.to_s
+
+          get "/api/v1/invoice_items/find?updated_at=#{date}"
+
+          invoice_item = JSON.parse(response.body)['data']
+
+          expect(response).to be_successful
+          expect(invoice_item['attributes']['id']).to eq(@invoice_item.id)
+        end
+      end
+
+    describe "multi-finders" do
+      describe "return all matches by any attribute" do
+        before :each do
+          @invoice_item_1 = create(:invoice_item, created_at: "19-12-05", updated_at: "20-02-04")
+          @invoice_item_2 = create(:invoice_item, created_at: "19-12-25", updated_at: "20-03-05")
+          @invoice_item_3 = create(:invoice_item, created_at: "19-12-25", updated_at: "20-02-04")
+          @invoice_item_4 = create(:invoice_item, first_name: @invoice_item_3.first_name, last_name: @invoice_item_3.last_name, created_at: "20-1-30", updated_at: "20-03-05")
+        end
+
+        xit "find all by id" do
+          get "/api/v1/invoice_items/find_all?id=#{@invoice_item_1.id}"
+
+          expect(response).to be_successful
+
+          invoice_items = JSON.parse(response.body)['data']
+
+          expect(invoice_items.count).to eq(1)
+
+          expect(invoice_items.first['attributes']['id']).to eq(@invoice_item_1.id)
+        end
+
+        xit "find all by first_name" do
+          invoice_item_1_first_names = [@invoice_item_1.first_name, @invoice_item_1.first_name.upcase, @invoice_item_1.first_name.downcase]
+
+          invoice_item_1_first_names.each do |first_name|
+            get "/api/v1/invoice_items/find_all?first_name=#{first_name}"
+            expect(response).to be_successful
+            invoice_items = JSON.parse(response.body)['data']
+            expect(invoice_items.count).to eq(1)
+            expect(invoice_items.first['attributes']['id']).to eq(@invoice_item_1.id)
+          end
+
+          name_2 = @invoice_item_3.first_name
+
+          get "/api/v1/invoice_items/find_all?first_name=#{name_2}"
+
+          invoice_items = JSON.parse(response.body)['data']
+
+          expect(invoice_items.count).to eq(2)
+
+          expect(invoice_items.first['attributes']['id']).to eq(@invoice_item_3.id)
+          expect(invoice_items.last['attributes']['id']).to eq(@invoice_item_4.id)
+        end
+
+        xit "find all by last_name" do
+          invoice_item_1_last_names = [@invoice_item_1.last_name, @invoice_item_1.last_name.upcase, @invoice_item_1.last_name.downcase]
+
+          invoice_item_1_last_names.each do |last_name|
+            get "/api/v1/invoice_items/find_all?last_name=#{last_name}"
+            expect(response).to be_successful
+            invoice_items = JSON.parse(response.body)['data']
+            expect(invoice_items.count).to eq(1)
+            expect(invoice_items.first['attributes']['id']).to eq(@invoice_item_1.id)
+          end
+
+          last_name_2 = @invoice_item_3.last_name
+
+          get "/api/v1/invoice_items/find_all?last_name=#{last_name_2}"
+
+          invoice_items = JSON.parse(response.body)['data']
+
+          expect(invoice_items.count).to eq(2)
+
+          expect(invoice_items.first['attributes']['id']).to eq(@invoice_item_3.id)
+          expect(invoice_items.last['attributes']['id']).to eq(@invoice_item_4.id)
+        end
+
+        xit "find all by created_at" do
+          date_1 = @invoice_item_1.created_at
+
+          get "/api/v1/invoice_items/find_all?created_at=#{date_1}"
+
+          expect(response).to be_successful
+
+          invoice_items = JSON.parse(response.body)['data']
+
+          expect(invoice_items.count).to eq(1)
+
+          expect(invoice_items.first['attributes']['id']).to eq(@invoice_item_1.id)
+
+          date_2 = @invoice_item_2.created_at
+
+          get "/api/v1/invoice_items/find_all?created_at=#{date_2}"
+
+          invoice_items = JSON.parse(response.body)['data']
+
+          expect(invoice_items.count).to eq(2)
+
+          expect(invoice_items.first['attributes']['id']).to eq(@invoice_item_2.id)
+          expect(invoice_items.last['attributes']['id']).to eq(@invoice_item_3.id)
+        end
+
+        xit "find all by updated_at" do
+          date_1 = @invoice_item_1.updated_at
+
+          get "/api/v1/invoice_items/find_all?updated_at=#{date_1}"
+
+          expect(response).to be_successful
+
+          invoice_items = JSON.parse(response.body)['data']
+
+          expect(invoice_items.count).to eq(2)
+
+          expect(invoice_items.first['attributes']['id']).to eq(@invoice_item_1.id)
+          expect(invoice_items.last['attributes']['id']).to eq(@invoice_item_3.id)
+
+          date_2 = @invoice_item_2.updated_at
+
+          get "/api/v1/invoice_items/find_all?updated_at=#{date_2}"
+
+          invoice_items = JSON.parse(response.body)['data']
+
+          expect(invoice_items.count).to eq(2)
+
+          expect(invoice_items.first['attributes']['id']).to eq(@invoice_item_2.id)
+          expect(invoice_items.last['attributes']['id']).to eq(@invoice_item_4.id)
+        end
+      end
+    end
+
+    describe "random" do
+      xit "returns a random invoice_item" do
+        invoice_items = create_list(:invoice_item, 10)
+
+        get "/api/v1/invoice_items/random"
+
+        expect(response).to be_successful
+
+        number_of_invoice_items = JSON.parse(response.body).count
+        expect(number_of_invoice_items).to eq(1)
+
+        random_invoice_item = JSON.parse(response.body)['data']
+
+        expect(random_invoice_item['type']).to eq('invoice_item')
+        expect(random_invoice_item['attributes'].keys).to match_array(['id', 'first_name', 'last_name'])
+
+        # could test the range instead?
+        result = invoice_items.one? { |invoice_item| invoice_item.id == random_invoice_item['attributes']['id'] }
+        expect(result).to be(true)
+      end
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/invoice_items/invoice_items_finders_spec.rb
+++ b/spec/requests/api/v1/invoice_items/invoice_items_finders_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe "Invoice Items API" do
           expect(invoice_item['attributes']['id']).to eq(@invoice_item.id)
         end
       end
+    end
 
     describe "multi-finders" do
       describe "return all matches by any attribute" do
@@ -225,10 +226,8 @@ RSpec.describe "Invoice Items API" do
         expect(random_invoice_item['type']).to eq('invoice_item')
         expect(random_invoice_item['attributes'].keys).to match_array(['id', 'invoice_id', 'item_id', 'quantity', 'unit_price'])
 
-        # could test the range instead?
         result = invoice_items.one? { |invoice_item| invoice_item.id == random_invoice_item['attributes']['id'] }
         expect(result).to be(true)
-      end
       end
     end
   end

--- a/spec/requests/api/v1/invoice_items/invoice_items_finders_spec.rb
+++ b/spec/requests/api/v1/invoice_items/invoice_items_finders_spec.rb
@@ -37,6 +37,15 @@ RSpec.describe "Invoice Items API" do
           expect(item_invoice['attributes']['id']).to eq(@invoice_item.id)
         end
 
+        it "invoice_id" do
+          get "/api/v1/invoice_items/find?invoice_id=#{@invoice_item.invoice_id}"
+
+          item_invoice = JSON.parse(response.body)['data']
+          expect(response).to be_successful
+
+          expect(item_invoice['attributes']['id']).to eq(@invoice_item.id)
+        end
+
         it "created_at" do
           date = @invoice_item.created_at.to_s
 
@@ -66,10 +75,10 @@ RSpec.describe "Invoice Items API" do
           @invoice_item_1 = create(:invoice_item, created_at: "19-12-05", updated_at: "20-02-04")
           @invoice_item_2 = create(:invoice_item, created_at: "19-12-25", updated_at: "20-03-05")
           @invoice_item_3 = create(:invoice_item, created_at: "19-12-25", updated_at: "20-02-04")
-          @invoice_item_4 = create(:invoice_item, first_name: @invoice_item_3.first_name, last_name: @invoice_item_3.last_name, created_at: "20-1-30", updated_at: "20-03-05")
+          @invoice_item_4 = create(:invoice_item, invoice: @invoice_item_3.invoice, quantity: @invoice_item_3.quantity, unit_price: @invoice_item_3.unit_price, created_at: "20-1-30", updated_at: "20-03-05")
         end
 
-        xit "find all by id" do
+        it "find all by id" do
           get "/api/v1/invoice_items/find_all?id=#{@invoice_item_1.id}"
 
           expect(response).to be_successful
@@ -81,20 +90,20 @@ RSpec.describe "Invoice Items API" do
           expect(invoice_items.first['attributes']['id']).to eq(@invoice_item_1.id)
         end
 
-        xit "find all by first_name" do
-          invoice_item_1_first_names = [@invoice_item_1.first_name, @invoice_item_1.first_name.upcase, @invoice_item_1.first_name.downcase]
+        it "find all by quantity" do
+          get "/api/v1/invoice_items/find_all?quantity=#{@invoice_item_1.quantity}"
 
-          invoice_item_1_first_names.each do |first_name|
-            get "/api/v1/invoice_items/find_all?first_name=#{first_name}"
-            expect(response).to be_successful
-            invoice_items = JSON.parse(response.body)['data']
-            expect(invoice_items.count).to eq(1)
-            expect(invoice_items.first['attributes']['id']).to eq(@invoice_item_1.id)
-          end
+          expect(response).to be_successful
 
-          name_2 = @invoice_item_3.first_name
+          invoice_items = JSON.parse(response.body)['data']
 
-          get "/api/v1/invoice_items/find_all?first_name=#{name_2}"
+          expect(invoice_items.count).to eq(1)
+
+          expect(invoice_items.first['attributes']['id']).to eq(@invoice_item_1.id)
+
+          quantity_2 = @invoice_item_3.quantity
+
+          get "/api/v1/invoice_items/find_all?quantity=#{quantity_2}"
 
           invoice_items = JSON.parse(response.body)['data']
 
@@ -104,20 +113,20 @@ RSpec.describe "Invoice Items API" do
           expect(invoice_items.last['attributes']['id']).to eq(@invoice_item_4.id)
         end
 
-        xit "find all by last_name" do
-          invoice_item_1_last_names = [@invoice_item_1.last_name, @invoice_item_1.last_name.upcase, @invoice_item_1.last_name.downcase]
+        it "find all by unit_price" do
+          get "/api/v1/invoice_items/find_all?unit_price=#{@invoice_item_1.unit_price}"
 
-          invoice_item_1_last_names.each do |last_name|
-            get "/api/v1/invoice_items/find_all?last_name=#{last_name}"
-            expect(response).to be_successful
-            invoice_items = JSON.parse(response.body)['data']
-            expect(invoice_items.count).to eq(1)
-            expect(invoice_items.first['attributes']['id']).to eq(@invoice_item_1.id)
-          end
+          expect(response).to be_successful
 
-          last_name_2 = @invoice_item_3.last_name
+          invoice_items = JSON.parse(response.body)['data']
 
-          get "/api/v1/invoice_items/find_all?last_name=#{last_name_2}"
+          expect(invoice_items.count).to eq(1)
+
+          expect(invoice_items.first['attributes']['id']).to eq(@invoice_item_1.id)
+
+          quantity_2 = @invoice_item_3.unit_price
+
+          get "/api/v1/invoice_items/find_all?unit_price=#{quantity_2}"
 
           invoice_items = JSON.parse(response.body)['data']
 
@@ -127,7 +136,27 @@ RSpec.describe "Invoice Items API" do
           expect(invoice_items.last['attributes']['id']).to eq(@invoice_item_4.id)
         end
 
-        xit "find all by created_at" do
+        it "find all by invoice_id" do
+          get "/api/v1/invoice_items/find_all?invoice_id=#{@invoice_item_1.invoice_id}"
+          expect(response).to be_successful
+          invoice_items = JSON.parse(response.body)['data']
+          expect(invoice_items.count).to eq(1)
+          expect(invoice_items.first['attributes']['id']).to eq(@invoice_item_1.id)
+
+
+          invoice_id_2 = @invoice_item_3.invoice_id
+
+          get "/api/v1/invoice_items/find_all?invoice_id=#{invoice_id_2}"
+
+          invoice_items = JSON.parse(response.body)['data']
+
+          expect(invoice_items.count).to eq(2)
+
+          expect(invoice_items.first['attributes']['id']).to eq(@invoice_item_3.id)
+          expect(invoice_items.last['attributes']['id']).to eq(@invoice_item_4.id)
+        end
+
+        it "find all by created_at" do
           date_1 = @invoice_item_1.created_at
 
           get "/api/v1/invoice_items/find_all?created_at=#{date_1}"
@@ -152,7 +181,7 @@ RSpec.describe "Invoice Items API" do
           expect(invoice_items.last['attributes']['id']).to eq(@invoice_item_3.id)
         end
 
-        xit "find all by updated_at" do
+        it "find all by updated_at" do
           date_1 = @invoice_item_1.updated_at
 
           get "/api/v1/invoice_items/find_all?updated_at=#{date_1}"

--- a/spec/requests/api/v1/invoice_items/invoice_items_finders_spec.rb
+++ b/spec/requests/api/v1/invoice_items/invoice_items_finders_spec.rb
@@ -210,7 +210,7 @@ RSpec.describe "Invoice Items API" do
     end
 
     describe "random" do
-      xit "returns a random invoice_item" do
+      it "returns a random invoice_item" do
         invoice_items = create_list(:invoice_item, 10)
 
         get "/api/v1/invoice_items/random"
@@ -223,7 +223,7 @@ RSpec.describe "Invoice Items API" do
         random_invoice_item = JSON.parse(response.body)['data']
 
         expect(random_invoice_item['type']).to eq('invoice_item')
-        expect(random_invoice_item['attributes'].keys).to match_array(['id', 'first_name', 'last_name'])
+        expect(random_invoice_item['attributes'].keys).to match_array(['id', 'invoice_id', 'item_id', 'quantity', 'unit_price'])
 
         # could test the range instead?
         result = invoice_items.one? { |invoice_item| invoice_item.id == random_invoice_item['attributes']['id'] }

--- a/spec/requests/api/v1/items/items_request_spec.rb
+++ b/spec/requests/api/v1/items/items_request_spec.rb
@@ -89,7 +89,7 @@ describe "Items API" do
           expect(item['attributes']['id']).to eq(@item.id)
         end
       end
-
+### needs to be tested
       it "find by unit_price" do
         unit_price = "274.09"
         get "/api/v1/items/find?unit_price=#{unit_price}"
@@ -136,7 +136,7 @@ describe "Items API" do
         @item_1 = create(:item, created_at: "19-12-05", updated_at: "20-02-04")
         @item_2 = create(:item, created_at: "19-12-25", updated_at: "20-03-05")
         @item_3 = create(:item, merchant: @item_2.merchant, created_at: "19-12-25", updated_at: "20-02-04")
-        @item_4 = create(:item, name: @item_3.name, description: @item_3.description, created_at: "20-1-30", updated_at: "20-03-05")
+        @item_4 = create(:item, name: @item_3.name, unit_price: @item_3.unit_price, description: @item_3.description, created_at: "20-1-30", updated_at: "20-03-05")
       end
 
       it "find all by id" do
@@ -170,6 +170,27 @@ describe "Items API" do
 
         expect(items.first['attributes']['id']).to eq(@item_2.id)
         expect(items.last['attributes']['id']).to eq(@item_3.id)
+      end
+
+      it "find all by unit_price" do
+        get "/api/v1/items/find_all?unit_price=#{@item_1.unit_price}"
+
+        expect(response).to be_successful
+
+        items = JSON.parse(response.body)['data']
+
+        expect(items.count).to eq(1)
+
+        expect(items.first['attributes']['id']).to eq(@item_1.id)
+
+        get "/api/v1/items/find_all?unit_price=#{@item_3.unit_price}"
+
+        items = JSON.parse(response.body)['data']
+
+        expect(items.count).to eq(2)
+
+        expect(items.first['attributes']['id']).to eq(@item_3.id)
+        expect(items.last['attributes']['id']).to eq(@item_4.id)
       end
 
       it "find all by name" do
@@ -397,7 +418,7 @@ describe "Items API" do
       expect(response).to be_successful
 
       best_day = JSON.parse(response.body)['data']
-      
+
       expect(best_day['attributes']['best_day']).to eq("2018-02-04")
     end
    end


### PR DESCRIPTION
**Functionality:**
- Adds request endpoints for invoice items index and show
- Adds all single finders by attribute for invoice items
- Adds all multi finders by attribute for invoice_items
- Adds random search feature to invoice_items

**Testing:**
- Rspec: 100% 
- Spec Harness: Invoice Items endpoints: 16/16, Full: 30 tests remaining

**Related Issues:**
- #14 #19 #28 #65 #random